### PR TITLE
Update README.md, fix possible naming collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,140 @@ Iapetus Edition provides the Integrations modeling backed by Apache Camel, manag
 
 It is good for exploration the Integration scenarios included the hundreds of available adapters.
 
-#### Docker
+<!-- TOC -->
+* [codbex-iapetus](#codbex-iapetus)
+  * [Run steps](#run-steps)
+    * [Start using Docker and released image](#start-using-docker-and-released-image)
+    * [Start using Docker and local sources](#start-using-docker-and-local-sources)
+      * [Build the project jar](#build-the-project-jar)
+      * [Build and run docker image locally](#build-and-run-docker-image-locally)
+    * [Java standalone application](#java-standalone-application)
+      * [Start the application](#start-the-application)
+      * [Start the application **in debug** with debug port `8000`](#start-the-application-in-debug-with-debug-port-8000)
+    * [Run unit tests](#run-unit-tests)
+    * [Run integration tests](#run-integration-tests)
+    * [Run all tests](#run-all-tests)
+    * [Format the code](#format-the-code)
+  * [Access the application](#access-the-application)
+  * [REST API](#rest-api)
+<!-- TOC -->
 
-```
-docker pull ghcr.io/codbex/codbex-iapetus:latest
-docker run --name codbex-iapetus --rm -p 80:80 ghcr.io/codbex/codbex-iapetus:latest
+## Run steps
+
+__Prerequisites:__
+- Export the following variables before executing the steps
+  ```shell
+  export GIT_REPO_FOLDER='<path-to-the-git-repo>'
+  export IMAGE='ghcr.io/codbex/codbex-iapetus:latest'
+  export CONTAINER_NAME='iapetus'
+  ```
+
+### Start using Docker and released image
+
+```shell
+# optionally remove the existing container with that name
+docker rm -f "$CONTAINER_NAME"
+docker pull "$IMAGE"
+
+docker run --name "$CONTAINER_NAME" -p 80:80 "$IMAGE"
 ```
 
-#### Build
+---
 
-```
-mvn clean install
-```
-	
-#### Run
-
-```
-java -jar application/target/codbex-iapetus-application-*.jar
+### Start using Docker and local sources
+#### Build the project jar
+```shell
+cd $GIT_REPO_FOLDER
+mvn -T 1C clean install -P quick-build
 ```
 
-#### Debug
+#### Build and run docker image locally
 
-```
-java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 -jar application/target/codbex-iapetus-application-*.jar
-```
-	
-#### Web
+__Prerequisites:__ [Build the project jar](#build-the-project-jar)
 
-```
-http://localhost
+  ```shell
+  cd "$GIT_REPO_FOLDER/application"
+  
+  docker build . --tag "$IMAGE"
+  
+  # optionally remove the existing container with that name
+  docker rm -f "$CONTAINER_NAME"
+
+  docker run --name "$CONTAINER_NAME" -p 80:80 "$IMAGE"
+  ```
+
+--- 
+
+### Java standalone application
+__Prerequisites:__ [Build the project jar](#build-the-project-jar)
+
+#### Start the application
+```shell
+cd "$GIT_REPO_FOLDER"
+
+java \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    -jar application/target/codbex-iapetus-*.jar
 ```
 
-#### REST API
+#### Start the application **in debug** with debug port `8000`
+```shell
+cd "$GIT_REPO_FOLDER"
+
+export PHOEBE_AIRFLOW_WORK_DIR="$AIRFLOW_WORK_DIR"
+java \
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    -jar application/target/codbex-iapetus-*.jar
+```
+
+---
+
+### Run unit tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P unit-tests
+```
+
+---
+
+### Run integration tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P integration-tests
+```
+
+---
+
+### Run all tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P tests
+```
+
+---
+
+### Format the code
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn verify -P format
+```
+
+---
+
+## Access the application
+- Open URL [http://localhost:80](http://localhost:80)
+- Login with the default credentials username `admin` and password `admin`
+
+## REST API
 
 ```
 http://localhost/swagger-ui/index.html

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -8,6 +8,6 @@ RUN npm i -g typescript
 RUN apk add git
 RUN apk --no-cache add msttcorefonts-installer fontconfig && update-ms-fonts && fc-cache -f
 
-COPY target/*.jar codbex-iapetus.jar
+COPY target/codbex-iapetus-[0-9]*.jar codbex-iapetus.jar
 ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-jar", "/codbex-iapetus.jar"]
 EXPOSE 80 8081

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -408,6 +408,10 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codbex.platform</groupId>
         <artifactId>codbex-platform-parent</artifactId>
-        <version>10.6.50</version>
+        <version>11.1.2</version>
     </parent>
 
     <name>codbex - iapetus - parent</name>


### PR DESCRIPTION
Update README.md, fix possible naming collisions when starting with java -jar and during the Docker build